### PR TITLE
Add navigation to exchange book detailed view and generate requests

### DIFF
--- a/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
@@ -16,7 +16,6 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.navigation.NavDirections;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 

--- a/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
@@ -30,7 +30,7 @@ import com.example.unlibrary.databinding.FragmentBookListBinding;
 public class BooksFragment extends Fragment {
     private BooksSource mBooksSource;
     private FragmentBookListBinding mBinding;
-    private int mDirection;
+    private BooksRecyclerViewAdapter.OnItemClickListener mOnItemClickListener;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
@@ -51,14 +51,14 @@ public class BooksFragment extends Fragment {
     }
 
     /**
-     * Sets the direction source for the current fragment instantiation. Should be called during
+     * Sets the OnItemClickListener for the current fragment instantiation. Should be called during
      * {@link Fragment#onCreateView(LayoutInflater, ViewGroup, Bundle)} in the parent or
      * containing fragment.
      *
-     * @param direction object that implements {@link BooksSource#getBooks()} usually a view model
+     * @param onItemClickListener implementation of BooksFragment.OnItemClickListener
      */
-    public void setDirection(int direction) {
-        mDirection = direction;
+    public void setOnItemClickListener(BooksRecyclerViewAdapter.OnItemClickListener onItemClickListener) {
+        mOnItemClickListener = onItemClickListener;
     }
 
     /**
@@ -78,7 +78,7 @@ public class BooksFragment extends Fragment {
 
         view.setLayoutManager(new LinearLayoutManager(context));
 
-        BooksRecyclerViewAdapter adapter = new BooksRecyclerViewAdapter(mBooksSource.getBooks().getValue(), mDirection);
+        BooksRecyclerViewAdapter adapter = new BooksRecyclerViewAdapter(mBooksSource.getBooks().getValue(), mOnItemClickListener);
 
         // Bind ViewModel books to RecyclerViewAdapter
         view.setAdapter(adapter);

--- a/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksFragment.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.NavDirections;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -29,6 +30,7 @@ import com.example.unlibrary.databinding.FragmentBookListBinding;
 public class BooksFragment extends Fragment {
     private BooksSource mBooksSource;
     private FragmentBookListBinding mBinding;
+    private int mDirection;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
@@ -49,6 +51,17 @@ public class BooksFragment extends Fragment {
     }
 
     /**
+     * Sets the direction source for the current fragment instantiation. Should be called during
+     * {@link Fragment#onCreateView(LayoutInflater, ViewGroup, Bundle)} in the parent or
+     * containing fragment.
+     *
+     * @param direction object that implements {@link BooksSource#getBooks()} usually a view model
+     */
+    public void setDirection(int direction) {
+        mDirection = direction;
+    }
+
+    /**
      * Draws the fragment UI
      *
      * @param inflater
@@ -65,7 +78,7 @@ public class BooksFragment extends Fragment {
 
         view.setLayoutManager(new LinearLayoutManager(context));
 
-        BooksRecyclerViewAdapter adapter = new BooksRecyclerViewAdapter(mBooksSource.getBooks().getValue());
+        BooksRecyclerViewAdapter adapter = new BooksRecyclerViewAdapter(mBooksSource.getBooks().getValue(), mDirection);
 
         // Bind ViewModel books to RecyclerViewAdapter
         view.setAdapter(adapter);

--- a/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
@@ -10,6 +10,7 @@ package com.example.unlibrary.book_list;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
@@ -17,6 +18,7 @@ import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.example.unlibrary.BR;
 import com.example.unlibrary.databinding.FragmentBookCardBinding;
 import com.example.unlibrary.models.Book;
 import com.example.unlibrary.util.BookViewHolder;
@@ -26,17 +28,17 @@ import java.util.List;
 /**
  * {@link RecyclerView.Adapter} that can display a {@link Book}
  */
-public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolder<FragmentBookCardBinding>> {
+public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BooksRecyclerViewAdapter.BookViewHolder> {
     protected List<Book> mBooks;
-    private int mDirection;
+    private final OnItemClickListener mOnItemClickListener;
 
     /**
      * Constructs the RecyclerAdapter with an initial list of books (may be null).
      *
      * @param books initial list of books
      */
-    public BooksRecyclerViewAdapter(List<Book> books, int direction) {
-        mDirection = direction;
+    public BooksRecyclerViewAdapter(List<Book> books, OnItemClickListener onItemCLickListener) {
+        mOnItemClickListener = onItemCLickListener;
         mBooks = books;
     }
 
@@ -60,10 +62,10 @@ public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolde
      */
     @NonNull
     @Override
-    public BookViewHolder<FragmentBookCardBinding> onCreateViewHolder(ViewGroup parent, int viewType) {
+    public BookViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater layoutInflater = LayoutInflater.from(parent.getContext());
         FragmentBookCardBinding bookBinding = FragmentBookCardBinding.inflate(layoutInflater, parent, false);
-        return new BookViewHolder<>(bookBinding);
+        return new BookViewHolder(bookBinding);
     }
 
     /**
@@ -73,17 +75,7 @@ public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolde
      * @param position index of the view holder in the list
      */
     @Override
-    public void onBindViewHolder(final BookViewHolder<FragmentBookCardBinding> holder, int position) {
-
-        // TODO: remove when they are done
-        if (mDirection != 0) {
-            holder.itemView.setOnClickListener(view -> {
-                Bundle bundle = new Bundle();
-                bundle.putInt("position", position);
-                Navigation.findNavController(view).navigate(mDirection, bundle);
-            });
-        }
-
+    public void onBindViewHolder(final BookViewHolder holder, int position) {
         Book book = mBooks.get(position);
         holder.bind(book);
     }
@@ -96,5 +88,58 @@ public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolde
     @Override
     public int getItemCount() {
         return mBooks.size();
+    }
+
+    /**
+     * Interface that must be implemented by anywhere that uses a book list.
+     */
+    public interface OnItemClickListener {
+        /**
+         * Called when a book list card is clicked.
+         *
+         * @param v        Card view
+         * @param position Position of card in the list
+         */
+        void onItemClicked(View v, int position);
+    }
+
+    /**
+     * ViewHolder for the book list recycler view. Contains a book card. Handles on click interactions.
+     * Defined inline as a closure and non-generically because it is already assuming that it will be
+     * binding to a book.
+     */
+    public class BookViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+        private final FragmentBookCardBinding mBinding;
+
+        /**
+         * Build the holder and setup the onClickListener.
+         *
+         * @param binding Binding for the holder
+         */
+        public BookViewHolder(FragmentBookCardBinding binding) {
+            super(binding.getRoot());
+            this.mBinding = binding;
+            mBinding.getRoot().setOnClickListener(this);
+        }
+
+        /**
+         * Bind a book to the card.
+         *
+         * @param book Book to bind to the card.
+         */
+        public void bind(Book book) {
+            mBinding.setVariable(BR.book, book);
+            mBinding.executePendingBindings();
+        }
+
+        /**
+         * To be called when a card is clicked.
+         *
+         * @param v View of the card
+         */
+        @Override
+        public void onClick(View v) {
+            mOnItemClickListener.onItemClicked(v, this.getLayoutPosition());
+        }
     }
 }

--- a/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
@@ -8,10 +8,13 @@
 
 package com.example.unlibrary.book_list;
 
+import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
+import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.unlibrary.databinding.FragmentBookCardBinding;
@@ -25,13 +28,15 @@ import java.util.List;
  */
 public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolder<FragmentBookCardBinding>> {
     protected List<Book> mBooks;
+    private int mDirection;
 
     /**
      * Constructs the RecyclerAdapter with an initial list of books (may be null).
      *
      * @param books initial list of books
      */
-    public BooksRecyclerViewAdapter(List<Book> books) {
+    public BooksRecyclerViewAdapter(List<Book> books, int direction) {
+        mDirection = direction;
         mBooks = books;
     }
 
@@ -69,6 +74,16 @@ public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BookViewHolde
      */
     @Override
     public void onBindViewHolder(final BookViewHolder<FragmentBookCardBinding> holder, int position) {
+
+        // TODO: remove when they are done
+        if (mDirection != 0) {
+            holder.itemView.setOnClickListener(view -> {
+                Bundle bundle = new Bundle();
+                bundle.putInt("position", position);
+                Navigation.findNavController(view).navigate(mDirection, bundle);
+            });
+        }
+
         Book book = mBooks.get(position);
         holder.bind(book);
     }

--- a/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
+++ b/app/src/main/java/com/example/unlibrary/book_list/BooksRecyclerViewAdapter.java
@@ -14,14 +14,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.navigation.NavDirections;
-import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.unlibrary.BR;
 import com.example.unlibrary.databinding.FragmentBookCardBinding;
 import com.example.unlibrary.models.Book;
-import com.example.unlibrary.util.BookViewHolder;
+
 
 import java.util.List;
 
@@ -56,7 +54,7 @@ public class BooksRecyclerViewAdapter extends RecyclerView.Adapter<BooksRecycler
      * Inflate fragment_book_card and bind it with the {@link BookViewHolder} class. OnClickListeners
      * can be passed here as well.
      *
-     * @param parent ViewGroup of which this View will be added after binding
+     * @param parent   ViewGroup of which this View will be added after binding
      * @param viewType layout ID
      * @return a new ViewHolder that holds a View for a {@link Book}
      */

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -1,0 +1,60 @@
+/*
+ * LibraryBookDetailsFragment
+ *
+ * October 30, 2020
+ *
+ * Copyright (c) Team 24, Fall2020, CMPUT301, University of Alberta
+ */
+package com.example.unlibrary.exchange;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
+
+import com.example.unlibrary.MainActivity;
+import com.example.unlibrary.databinding.FragmentExchangeBookDetailsBinding;
+import com.example.unlibrary.databinding.FragmentLibraryBookDetailsBinding;
+import com.example.unlibrary.models.Book;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fragment to display the details and requests upon a user owned book.
+ */
+public class ExchangeBookDetailsFragment extends Fragment {
+
+    private FragmentExchangeBookDetailsBinding mBinding;
+
+    /**
+     * Setup the fragment
+     *
+     * @param inflater           default
+     * @param container          default
+     * @param savedInstanceState default
+     * @return fragment view
+     */
+    @Override
+    public View onCreateView(@NotNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        // Get the activity viewModel
+        ExchangeViewModel mViewModel = new ViewModelProvider(requireActivity()).get(ExchangeViewModel.class);
+
+        int position = getArguments().getInt("position");
+        Book currentBook = mViewModel.getBooks().getValue().get(position);
+        mViewModel.setCurrentBook(currentBook);
+
+        // Setup data binding
+        mBinding = FragmentExchangeBookDetailsBinding.inflate(inflater, container, false);
+        mBinding.setViewModel(mViewModel);
+        mBinding.setLifecycleOwner(getViewLifecycleOwner());
+
+        //set up observer
+        mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
+
+        return mBinding.getRoot();
+    }
+}

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -42,11 +42,6 @@ public class ExchangeBookDetailsFragment extends Fragment {
     public View onCreateView(@NotNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         // Get the activity viewModel
         ExchangeViewModel mViewModel = new ViewModelProvider(requireActivity()).get(ExchangeViewModel.class);
-
-        int position = getArguments().getInt("position");
-        Book currentBook = mViewModel.getBooks().getValue().get(position);
-        mViewModel.setCurrentBook(currentBook);
-
         // Setup data binding
         mBinding = FragmentExchangeBookDetailsBinding.inflate(inflater, container, false);
         mBinding.setViewModel(mViewModel);
@@ -54,6 +49,7 @@ public class ExchangeBookDetailsFragment extends Fragment {
 
         //set up observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
+        mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 
         return mBinding.getRoot();
     }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -47,7 +47,7 @@ public class ExchangeBookDetailsFragment extends Fragment {
         mBinding.setViewModel(mViewModel);
         mBinding.setLifecycleOwner(getViewLifecycleOwner());
 
-        //set up observer
+        //Setup observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -47,7 +47,7 @@ public class ExchangeBookDetailsFragment extends Fragment {
         mBinding.setViewModel(mViewModel);
         mBinding.setLifecycleOwner(getViewLifecycleOwner());
 
-        //Setup observer
+        // Setup observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
@@ -16,14 +16,16 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 
 import com.example.unlibrary.book_list.BooksFragment;
+import com.example.unlibrary.book_list.BooksRecyclerViewAdapter;
 import com.example.unlibrary.databinding.FragmentExchangeBinding;
 
 /**
  * Host fragment for Exchange feature
  */
-public class ExchangeFragment extends Fragment {
+public class ExchangeFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
     private ExchangeViewModel mViewModel;
     private FragmentExchangeBinding mBinding;
 
@@ -52,7 +54,7 @@ public class ExchangeFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mBinding = FragmentExchangeBinding.inflate(inflater, container, false);
         mBinding.setLifecycleOwner(getViewLifecycleOwner());
-        int direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment().getActionId();
+
 
         // Child fragments are can only be accessed on view creation, so this is the earliest
         // point where we can specify the data source
@@ -61,10 +63,21 @@ public class ExchangeFragment extends Fragment {
                 BooksFragment bookFragment = (BooksFragment) f;
 
                 bookFragment.setBooksSource(mViewModel);
-                bookFragment.setDirection(direction);
+                bookFragment.setOnItemClickListener(this);
             }
         }
 
         return mBinding.getRoot();
+    }
+
+    /**
+     * Called when a book card is clicked on.
+     *
+     * @param v        View object of the card
+     * @param position Position of the card in the list
+     */
+    @Override
+    public void onItemClicked(View v, int position) {
+        mViewModel.selectCurrentBook(v, position);
     }
 }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
@@ -25,7 +25,7 @@ import com.example.unlibrary.databinding.FragmentExchangeBinding;
 /**
  * Host fragment for Exchange feature
  */
-public class ExchangeFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
+public class ExchangeFragment extends Fragment {
     private ExchangeViewModel mViewModel;
     private FragmentExchangeBinding mBinding;
 
@@ -62,21 +62,10 @@ public class ExchangeFragment extends Fragment implements BooksRecyclerViewAdapt
                 BooksFragment bookFragment = (BooksFragment) f;
 
                 bookFragment.setBooksSource(mViewModel);
-                bookFragment.setOnItemClickListener(this);
+                bookFragment.setOnItemClickListener(mViewModel::selectCurrentBook);
             }
         }
 
         return mBinding.getRoot();
-    }
-
-    /**
-     * Called when a book card is clicked on.
-     *
-     * @param v        View object of the card
-     * @param position Position of the card in the list
-     */
-    @Override
-    public void onItemClicked(View v, int position) {
-        mViewModel.selectCurrentBook(v, position);
     }
 }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
@@ -55,7 +55,6 @@ public class ExchangeFragment extends Fragment implements BooksRecyclerViewAdapt
         mBinding = FragmentExchangeBinding.inflate(inflater, container, false);
         mBinding.setLifecycleOwner(getViewLifecycleOwner());
 
-
         // Child fragments are can only be accessed on view creation, so this is the earliest
         // point where we can specify the data source
         for (Fragment f : getChildFragmentManager().getFragments()) {

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavDirections;
 
 import com.example.unlibrary.book_list.BooksFragment;
 import com.example.unlibrary.databinding.FragmentExchangeBinding;
@@ -51,13 +52,16 @@ public class ExchangeFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         mBinding = FragmentExchangeBinding.inflate(inflater, container, false);
         mBinding.setLifecycleOwner(getViewLifecycleOwner());
+        int direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment().getActionId();
 
         // Child fragments are can only be accessed on view creation, so this is the earliest
         // point where we can specify the data source
         for (Fragment f : getChildFragmentManager().getFragments()) {
             if (f instanceof BooksFragment) {
                 BooksFragment bookFragment = (BooksFragment) f;
+
                 bookFragment.setBooksSource(mViewModel);
+                bookFragment.setDirection(direction);
             }
         }
 

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -33,7 +33,7 @@ import java.util.List;
  * Manages all the database interaction for the ExchangeViewModel.
  */
 public class ExchangeRepository {
-    private static final String REQUEST_COLLECTION = "test_request";
+    private static final String REQUEST_COLLECTION = "Requests";
     private static final String BOOK_COLLECTION = "books";
 
     private static final String TAG = ExchangeRepository.class.getSimpleName();

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -35,6 +35,8 @@ import java.util.List;
 public class ExchangeRepository {
     private static final String REQUEST_COLLECTION = "requests";
     private static final String BOOK_COLLECTION = "books";
+    private static final String OWNER = "owner";
+    private static final String STATUS = "status";
 
     private static final String TAG = ExchangeRepository.class.getSimpleName();
 
@@ -51,7 +53,7 @@ public class ExchangeRepository {
         mDb = FirebaseFirestore.getInstance();
         mBooks = new MutableLiveData<>(new ArrayList<>());
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-        
+
         // TODO: make sure user is authenticated
         mUID = user.getUid();
         attachListener();
@@ -72,8 +74,8 @@ public class ExchangeRepository {
      */
     public void attachListener() {
         mListenerRegistration = mDb.collection(BOOK_COLLECTION)
-                .whereIn("status", Arrays.asList(Book.Status.AVAILABLE, Book.Status.REQUESTED))
-                .whereNotEqualTo("owner", FirebaseAuth.getInstance().getUid())
+                .whereIn(STATUS, Arrays.asList(Book.Status.AVAILABLE, Book.Status.REQUESTED))
+                .whereNotEqualTo(OWNER, FirebaseAuth.getInstance().getUid())
                 .addSnapshotListener((value, error) -> {
                     if (error != null) {
                         Log.w(TAG, error);
@@ -120,6 +122,5 @@ public class ExchangeRepository {
     public void detachListener() {
         mListenerRegistration.remove();
     }
-
 }
 

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -51,6 +51,8 @@ public class ExchangeRepository {
         mDb = FirebaseFirestore.getInstance();
         mBooks = new MutableLiveData<>(new ArrayList<>());
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        
+        // TODO: make sure user is authenticated
         mUID = user.getUid();
         attachListener();
     }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -33,7 +33,7 @@ import java.util.List;
  * Manages all the database interaction for the ExchangeViewModel.
  */
 public class ExchangeRepository {
-    private static final String REQUEST_COLLECTION = "Requests";
+    private static final String REQUEST_COLLECTION = "requests";
     private static final String BOOK_COLLECTION = "books";
 
     private static final String TAG = ExchangeRepository.class.getSimpleName();
@@ -60,7 +60,7 @@ public class ExchangeRepository {
      *
      * @return unique identifier of user
      */
-    public String getUid () {
+    public String getUid() {
         return mUID;
     }
 
@@ -93,7 +93,7 @@ public class ExchangeRepository {
     /**
      * Save new Request into the database. Assumes Request is valid.
      *
-     * @param request              request object to be saved in the database
+     * @param request           request object to be saved in the database
      * @param onSuccessListener code to call on success
      * @param onFailureListener code to call on failure
      */

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -8,11 +8,17 @@
 
 package com.example.unlibrary.exchange;
 
+import android.util.Log;
+
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.navigation.NavDirections;
 
 import com.example.unlibrary.book_list.BooksSource;
 import com.example.unlibrary.models.Book;
+import com.example.unlibrary.models.Request;
+import com.example.unlibrary.util.SingleLiveEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +27,13 @@ import java.util.List;
  * Manages the Exchange flow business logic. Connects the exchange fragment to the repository.
  */
 public class ExchangeViewModel extends ViewModel implements BooksSource {
+    private static final String TAG = ExchangeViewModel.class.getSimpleName();
+
     private final LiveData<List<Book>> mBooks;
     private final ExchangeRepository mExchangeRepository;
+    private MutableLiveData<Book> mCurrentBook = new MutableLiveData<>();
+    private SingleLiveEvent<NavDirections> mNavigationEvent = new SingleLiveEvent<>();
+    private SingleLiveEvent<String> mFailureMsgEvent = new SingleLiveEvent<>();
 
     /**
      * Constructor for the ExchangeViewModel. Instantiates listener to Firestore.
@@ -33,12 +44,78 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     }
 
     /**
+     * FailureMsgEvent getter for activity observers.
+     *
+     * @return Event of failure message to display
+     */
+    public SingleLiveEvent<String> getFailureMsgEvent() {
+        if (mFailureMsgEvent == null) {
+            mFailureMsgEvent = new SingleLiveEvent<>();
+        }
+        return mFailureMsgEvent;
+    }
+
+    /**
+     * NavigationEvent getter for activity observers.
+     *
+     * @return Event of which fragment to navigate to
+     */
+    public SingleLiveEvent<NavDirections> getNavigationEvent() {
+        if (mNavigationEvent == null) {
+            mNavigationEvent = new SingleLiveEvent<>();
+        }
+        return mNavigationEvent;
+    }
+
+    /**
      * Getter for the mBooks live data object
      *
      * @return LiveData<ArrayList < Book>> This returns the mBooks object
      */
     public LiveData<List<Book>> getBooks() {
         return this.mBooks;
+    }
+
+    /**
+     * Getter for themCurrentBook live data object
+     *
+     * @return LiveData<Book> This returns the mBooks object
+     */
+    public LiveData<Book> getCurrentBook() {
+        return this.mCurrentBook;
+    }
+
+    /**
+     * Setter for the mCurrentBook live data object
+     *
+     */
+    public void setCurrentBook(Book book) {
+        mCurrentBook.setValue(book);
+    }
+
+    /**
+     * Getter for the description of the book.
+     *
+     * @return String This returns book description
+     */
+    public String getDescription() {
+        Book currentBook = mCurrentBook.getValue();
+        return String.format("%s %s %s", currentBook.getIsbn(), currentBook.getTitle(), currentBook.getAuthor());
+    }
+
+    /**
+     * Generates and saves the request into firestore.
+     */
+    public void sendRequest() {
+        Request request = new Request(mExchangeRepository.getUid(), mCurrentBook.getValue().getId());
+        mExchangeRepository.createRequest(request,
+                o -> {
+                    mNavigationEvent.setValue(ExchangeBookDetailsFragmentDirections.actionExchangeBookDetailsFragmentToExchangeFragment());
+                },
+                e -> {
+                    mFailureMsgEvent.setValue("Failed to send request.");
+                    Log.e(TAG, "Failed to send request.", e);
+                });
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -79,7 +79,7 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     }
 
     /**
-     * Getter for themCurrentBook live data object
+     * Getter for mCurrentBook live data object
      *
      * @return LiveData<Book> This returns the mBooks object
      */
@@ -112,17 +112,23 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
                 });
     }
 
-    public void selectCurrentBook (View view, int position) {
+    /**
+     * Sets mCurrentBook and navigates to detailed book view.
+     *
+     * @param view     view to navigate from.
+     * @param position list position of selected book.
+     */
+    public void selectCurrentBook(View view, int position) {
         if (mBooks.getValue() == null) {
             mFailureMsgEvent.setValue("Failed show details for book");
-        }
-        else{
+        } else {
             Book book = mBooks.getValue().get(position);
             mCurrentBook.setValue(book);
             NavDirections direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment();
             Navigation.findNavController(view).navigate(direction);
         }
     }
+
     /**
      * Cleans up resources, removes the snapshot listener from the repository.
      */

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -9,11 +9,13 @@
 package com.example.unlibrary.exchange;
 
 import android.util.Log;
+import android.view.View;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 
 import com.example.unlibrary.book_list.BooksSource;
 import com.example.unlibrary.models.Book;
@@ -86,14 +88,6 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     }
 
     /**
-     * Setter for the mCurrentBook live data object
-     *
-     */
-    public void setCurrentBook(Book book) {
-        mCurrentBook.setValue(book);
-    }
-
-    /**
      * Getter for the description of the book.
      *
      * @return String This returns book description
@@ -118,6 +112,17 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
                 });
     }
 
+    public void selectCurrentBook (View view, int position) {
+        if (mBooks.getValue() == null) {
+            mFailureMsgEvent.setValue("Failed show details for book");
+        }
+        else{
+            Book book = mBooks.getValue().get(position);
+            mCurrentBook.setValue(book);
+            NavDirections direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment();
+            Navigation.findNavController(view).navigate(direction);
+        }
+    }
     /**
      * Cleans up resources, removes the snapshot listener from the repository.
      */

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -105,12 +105,14 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     public void selectCurrentBook(View view, int position) {
         if (mBooks.getValue() == null) {
             mFailureMsgEvent.setValue("Failed show details for book");
-        } else {
-            Book book = mBooks.getValue().get(position);
-            mCurrentBook.setValue(book);
-            NavDirections direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment();
-            Navigation.findNavController(view).navigate(direction);
+            return;
         }
+
+        Book book = mBooks.getValue().get(position);
+        mCurrentBook.setValue(book);
+        NavDirections direction = ExchangeFragmentDirections.actionExchangeFragmentToExchangeBookDetailsFragment();
+        Navigation.findNavController(view).navigate(direction);
+
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -33,9 +33,9 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
 
     private final LiveData<List<Book>> mBooks;
     private final ExchangeRepository mExchangeRepository;
-    private MutableLiveData<Book> mCurrentBook = new MutableLiveData<>();
-    private SingleLiveEvent<NavDirections> mNavigationEvent = new SingleLiveEvent<>();
-    private SingleLiveEvent<String> mFailureMsgEvent = new SingleLiveEvent<>();
+    private final MutableLiveData<Book> mCurrentBook = new MutableLiveData<>();
+    private final SingleLiveEvent<NavDirections> mNavigationEvent = new SingleLiveEvent<>();
+    private final SingleLiveEvent<String> mFailureMsgEvent = new SingleLiveEvent<>();
 
     /**
      * Constructor for the ExchangeViewModel. Instantiates listener to Firestore.
@@ -51,9 +51,6 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      * @return Event of failure message to display
      */
     public SingleLiveEvent<String> getFailureMsgEvent() {
-        if (mFailureMsgEvent == null) {
-            mFailureMsgEvent = new SingleLiveEvent<>();
-        }
         return mFailureMsgEvent;
     }
 
@@ -63,9 +60,6 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      * @return Event of which fragment to navigate to
      */
     public SingleLiveEvent<NavDirections> getNavigationEvent() {
-        if (mNavigationEvent == null) {
-            mNavigationEvent = new SingleLiveEvent<>();
-        }
         return mNavigationEvent;
     }
 
@@ -85,16 +79,6 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      */
     public LiveData<Book> getCurrentBook() {
         return this.mCurrentBook;
-    }
-
-    /**
-     * Getter for the description of the book.
-     *
-     * @return String This returns book description
-     */
-    public String getDescription() {
-        Book currentBook = mCurrentBook.getValue();
-        return String.format("%s %s %s", currentBook.getIsbn(), currentBook.getTitle(), currentBook.getAuthor());
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/library/LibraryFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryFragment.java
@@ -33,7 +33,7 @@ import com.google.firebase.auth.FirebaseUser;
 /**
  * Host fragment for Library feature
  */
-public class LibraryFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
+public class LibraryFragment extends Fragment {
     private LibraryViewModel mViewModel;
     private FragmentLibraryBinding mBinding;
 
@@ -73,7 +73,7 @@ public class LibraryFragment extends Fragment implements BooksRecyclerViewAdapte
             if (f instanceof BooksFragment) {
                 BooksFragment bookFragment = (BooksFragment) f;
                 bookFragment.setBooksSource(mViewModel);
-                bookFragment.setOnItemClickListener(this);
+                bookFragment.setOnItemClickListener(mViewModel::selectCurrentBook);
             }
         }
         mBinding.setViewModel(mViewModel);
@@ -84,16 +84,5 @@ public class LibraryFragment extends Fragment implements BooksRecyclerViewAdapte
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 
         return mBinding.getRoot();
-    }
-
-    /**
-     * Called when a book card is clicked on.
-     *
-     * @param v        View object of the card
-     * @param position Position of the card in the list
-     */
-    @Override
-    public void onItemClicked(View v, int position) {
-        //TODO
     }
 }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryFragment.java
@@ -18,11 +18,13 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.example.unlibrary.book_list.BooksFragment;
+
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 
 import com.example.unlibrary.MainActivity;
+import com.example.unlibrary.book_list.BooksRecyclerViewAdapter;
 import com.example.unlibrary.databinding.FragmentLibraryBinding;
 import com.example.unlibrary.models.Book;
 import com.google.firebase.auth.FirebaseAuth;
@@ -31,7 +33,7 @@ import com.google.firebase.auth.FirebaseUser;
 /**
  * Host fragment for Library feature
  */
-public class LibraryFragment extends Fragment {
+public class LibraryFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
     private LibraryViewModel mViewModel;
     private FragmentLibraryBinding mBinding;
 
@@ -51,8 +53,8 @@ public class LibraryFragment extends Fragment {
      * Sets up listeners to binding variables and sends {@link com.example.unlibrary.book_list.BooksSource}
      * to child {@link BooksFragment} to display.
      *
-     * @param inflater {@link LayoutInflater} that can be used to inflate any view in the fragment
-     * @param container {@link ViewGroup} possibly null parent view that this fragment will attach to
+     * @param inflater           {@link LayoutInflater} that can be used to inflate any view in the fragment
+     * @param container          {@link ViewGroup} possibly null parent view that this fragment will attach to
      * @param savedInstanceState bundle used to restore its previous state
      * @return {@link View} for this fragment
      */
@@ -71,6 +73,7 @@ public class LibraryFragment extends Fragment {
             if (f instanceof BooksFragment) {
                 BooksFragment bookFragment = (BooksFragment) f;
                 bookFragment.setBooksSource(mViewModel);
+                bookFragment.setOnItemClickListener(this);
             }
         }
         mBinding.setViewModel(mViewModel);
@@ -81,5 +84,16 @@ public class LibraryFragment extends Fragment {
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 
         return mBinding.getRoot();
+    }
+
+    /**
+     * Called when a book card is clicked on.
+     *
+     * @param v        View object of the card
+     * @param position Position of the card in the list
+     */
+    @Override
+    public void onItemClicked(View v, int position) {
+        //TODO
     }
 }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -10,15 +10,18 @@ package com.example.unlibrary.library;
 
 import android.util.Log;
 import android.util.Pair;
+import android.view.View;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 
 import com.example.unlibrary.book_list.BooksSource;
 import com.androidnetworking.error.ANError;
 import com.androidnetworking.interfaces.JSONObjectRequestListener;
+import com.example.unlibrary.exchange.ExchangeFragmentDirections;
 import com.example.unlibrary.models.Book;
 import com.example.unlibrary.util.BarcodeScanner;
 import com.example.unlibrary.util.SingleLiveEvent;
@@ -338,5 +341,15 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         public InvalidInputException(String errorMessage) {
             super(errorMessage);
         }
+    }
+
+    /**
+     * Sets mCurrentBook and navigates to detailed book view.
+     *
+     * @param view     view to navigate from.
+     * @param position list position of selected book.
+     */
+    public void selectCurrentBook(View view, int position) {
+        //TODO
     }
 }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -16,7 +16,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.navigation.NavDirections;
-import androidx.navigation.Navigation;
+
 
 import com.example.unlibrary.book_list.BooksSource;
 import com.androidnetworking.error.ANError;

--- a/app/src/main/java/com/example/unlibrary/models/Request.java
+++ b/app/src/main/java/com/example/unlibrary/models/Request.java
@@ -10,12 +10,13 @@ package com.example.unlibrary.models;
 
 import androidx.core.util.Pair;
 
+import com.google.firebase.firestore.DocumentId;
+
 import java.util.List;
 
 /**
  * Represents a borrow request in our application domain.
  * <p>
- * TODO: Link and retrieve ID from Firestore
  */
 public class Request {
     private String mId;
@@ -47,8 +48,22 @@ public class Request {
      *
      * @return unique identifier of request
      */
+    @DocumentId
     public String getId() {
         return mId;
+    }
+
+    /**
+     * Sets the unique identifier of a request obtained from Firestore.
+     *
+     * @return unique identifier of request
+     */
+    public void setId(String id) {
+        if (mId != null) {
+            throw new IllegalArgumentException("ID has already been initialized");
+        }
+
+        mId = id;
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryFragment.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryFragment.java
@@ -23,7 +23,7 @@ import com.example.unlibrary.databinding.FragmentUnlibraryBinding;
 /**
  * Host fragment for Unlibrary feature
  */
-public class UnlibraryFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
+public class UnlibraryFragment extends Fragment {
     private UnlibraryViewModel mViewModel;
     private FragmentUnlibraryBinding mBinding;
 
@@ -60,21 +60,10 @@ public class UnlibraryFragment extends Fragment implements BooksRecyclerViewAdap
             if (f instanceof BooksFragment) {
                 BooksFragment bookFragment = (BooksFragment) f;
                 bookFragment.setBooksSource(mViewModel);
-                bookFragment.setOnItemClickListener(this);
+                bookFragment.setOnItemClickListener(mViewModel::selectCurrentBook);
             }
         }
 
         return mBinding.getRoot();
-    }
-
-    /**
-     * Called when a book card is clicked on.
-     *
-     * @param v        View object of the card
-     * @param position Position of the card in the list
-     */
-    @Override
-    public void onItemClicked(View v, int position) {
-        //TODO
     }
 }

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryFragment.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryFragment.java
@@ -17,12 +17,13 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.example.unlibrary.book_list.BooksFragment;
+import com.example.unlibrary.book_list.BooksRecyclerViewAdapter;
 import com.example.unlibrary.databinding.FragmentUnlibraryBinding;
 
 /**
  * Host fragment for Unlibrary feature
  */
-public class UnlibraryFragment extends Fragment {
+public class UnlibraryFragment extends Fragment implements BooksRecyclerViewAdapter.OnItemClickListener {
     private UnlibraryViewModel mViewModel;
     private FragmentUnlibraryBinding mBinding;
 
@@ -59,9 +60,21 @@ public class UnlibraryFragment extends Fragment {
             if (f instanceof BooksFragment) {
                 BooksFragment bookFragment = (BooksFragment) f;
                 bookFragment.setBooksSource(mViewModel);
+                bookFragment.setOnItemClickListener(this);
             }
         }
 
         return mBinding.getRoot();
+    }
+
+    /**
+     * Called when a book card is clicked on.
+     *
+     * @param v        View object of the card
+     * @param position Position of the card in the list
+     */
+    @Override
+    public void onItemClicked(View v, int position) {
+        //TODO
     }
 }

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
@@ -8,10 +8,15 @@
 
 package com.example.unlibrary.unlibrary;
 
+import android.view.View;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 
 import com.example.unlibrary.book_list.BooksSource;
+import com.example.unlibrary.exchange.ExchangeFragmentDirections;
 import com.example.unlibrary.models.Book;
 
 import java.util.List;
@@ -47,5 +52,15 @@ public class UnlibraryViewModel extends ViewModel implements BooksSource {
     @Override
     protected void onCleared() {
         mUnlibraryRepository.detachListeners();
+    }
+
+    /**
+     * Sets mCurrentBook and navigates to detailed book view.
+     *
+     * @param view     view to navigate from.
+     * @param position list position of selected book.
+     */
+    public void selectCurrentBook(View view, int position) {
+        //TODO
     }
 }

--- a/app/src/main/res/layout/fragment_exchange_book_details.xml
+++ b/app/src/main/res/layout/fragment_exchange_book_details.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.example.unlibrary.exchange.ExchangeViewModel" />
+
+        <import type="android.view.View" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <include
+            android:id="@+id/profileImage"
+            layout="@layout/fragment_image_holder"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintHeight_percent="0.4"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:title="@{viewModel.currentBook.title}"
+            app:subtitle="@{viewModel.currentBook.author}" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_request"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_marginBottom="24dp"
+            android:contentDescription="@string/edit_book_fab_description"
+            android:onClick="@{()->viewModel.sendRequest()}"
+            app:layout_constraintBottom_toBottomOf="@+id/profileImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:srcCompat="@drawable/ic_add" />
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="16dp"
+            android:text="@string/isbn"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/profileImage" />
+
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="8dp"
+            android:text="@{viewModel.currentBook.isbn}"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+        <TextView
+            android:id="@+id/textView2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="@dimen/text_margin"
+            android:text="@string/book_description"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView5" />
+
+        <TextView
+            android:id="@+id/textView6"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="8dp"
+            android:text="@{viewModel.description}"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView2" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>
+

--- a/app/src/main/res/layout/fragment_exchange_book_details.xml
+++ b/app/src/main/res/layout/fragment_exchange_book_details.xml
@@ -7,8 +7,6 @@
         <variable
             name="viewModel"
             type="com.example.unlibrary.exchange.ExchangeViewModel" />
-
-        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -23,8 +21,8 @@
             app:layout_constraintHeight_percent="0.4"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:title="@{viewModel.currentBook.title}"
-            app:subtitle="@{viewModel.currentBook.author}" />
+            app:subtitle="@{viewModel.currentBook.author}"
+            app:title="@{viewModel.currentBook.title}" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/add_request"

--- a/app/src/main/res/layout/fragment_exchange_book_details.xml
+++ b/app/src/main/res/layout/fragment_exchange_book_details.xml
@@ -58,28 +58,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textView" />
 
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/text_margin"
-            android:layout_marginTop="@dimen/text_margin"
-            android:text="@string/book_description"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView5" />
-
-        <TextView
-            android:id="@+id/textView6"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/text_margin"
-            android:layout_marginTop="8dp"
-            android:text="@{viewModel.description}"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView2" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -34,7 +34,20 @@
         android:id="@+id/exchangeFragment"
         android:name="com.example.unlibrary.exchange.ExchangeFragment"
         android:label="fragment_exchange"
-        tools:layout="@layout/fragment_exchange" />
+        tools:layout="@layout/fragment_exchange" >
+        <action
+            android:id="@+id/action_exchangeFragment_to_exchangeBookDetailsFragment"
+            app:destination="@id/exchangeBookDetailsFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/exchangeBookDetailsFragment"
+        android:name="com.example.unlibrary.exchange.ExchangeBookDetailsFragment"
+        android:label="fragment_exchange_book_details"
+        tools:layout="@layout/fragment_exchange_book_details">
+        <action
+            android:id="@+id/action_exchange_book_details_fragment_to_exchangeFragment"
+            app:destination="@id/exchangeFragment" />
+    </fragment>
     <fragment
         android:id="@+id/libraryEditBookFragment"
         android:name="com.example.unlibrary.library.LibraryEditBookFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="delete_book_fab_description">Delete book</string>
     <string name="isbn">ISBN</string>
     <string name="request_status">Request Status</string>
+    <string name="book_description">Book Description</string>
 </resources>


### PR DESCRIPTION
<!-- Tip: Make the title of the PR the feature your PR will add e.g. Add profile page -->

# Summary
- Added Navigation from exchange book view to exchanging detailed book view when book is clicked
- From exchange detailed book view, user can generate a request that will be stored in firestore
- Navigates user back to exchange book view after the request is sent
- Request object now uses @DocumentId to get id from firestore

# TODO
- Add navigation to detailed book view from library and unlibrary
- Update book status for user after request
- Add success message after the user has sent the request

# Screenshots
![toDetailed](https://user-images.githubusercontent.com/44874031/97829203-89eae480-1c86-11eb-830e-d29f4ba5e587.gif)
![fromDetailed](https://user-images.githubusercontent.com/44874031/97829209-8f482f00-1c86-11eb-8302-db1e697b16d9.gif)

Co-Authored with @calebschoepp 

Closes #78 
