### PR TITLE
Update User Object

### DIFF
--- a/app/src/main/java/com/example/unlibrary/models/User.java
+++ b/app/src/main/java/com/example/unlibrary/models/User.java
@@ -14,7 +14,6 @@ import com.google.firebase.firestore.DocumentId;
  * Represents a user in our application domain. This user information is stored in Firestore and is
  * related to a user entry in Firebase.
  * <p>
- * TODO: Add authorization to secure allowed methods (e.g. editing user data)
  */
 public class User {
     private String mUID;

--- a/app/src/main/java/com/example/unlibrary/models/User.java
+++ b/app/src/main/java/com/example/unlibrary/models/User.java
@@ -8,15 +8,16 @@
 
 package com.example.unlibrary.models;
 
+import com.google.firebase.firestore.DocumentId;
+
 /**
  * Represents a user in our application domain. This user information is stored in Firestore and is
  * related to a user entry in Firebase.
  * <p>
- * TODO: Link with Firebase
  * TODO: Add authorization to secure allowed methods (e.g. editing user data)
  */
 public class User {
-    private String mId;
+    private String mUID;
     private String mUsername;
     private String mEmail;
 
@@ -34,18 +35,34 @@ public class User {
      * @param email    of the user
      */
     public User(String id, String username, String email) {
-        mId = id;
+        mUID = id;
         mUsername = username;
         mEmail = email;
     }
 
     /**
-     * Gets the unique identifier of the user.
+     * Gets the unique identifier of the user. Retrieved from Firestore.
      *
      * @return unique user id associated with the user
      */
-    public String getId() {
-        return mId;
+    @DocumentId
+    public String getUID() {
+        return mUID;
+    }
+
+    /**
+     * Updates the unique identifier of the user. Should not be called explicitly in code. This is
+     * called automatically when {@link com.google.firebase.firestore.DocumentSnapshot#toObject(Class)}
+     * is called when retrieving documents from Firestore.
+     *
+     * @param id unique identifier of user
+     */
+    public void setUID(String id) {
+        if (mUID != null) {
+            throw new IllegalArgumentException("ID has already been initialized");
+        }
+
+        mUID = id;
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/profile/ProfileRepository.java
+++ b/app/src/main/java/com/example/unlibrary/profile/ProfileRepository.java
@@ -53,9 +53,7 @@ public class ProfileRepository {
                 .get()
                 .addOnSuccessListener(task -> {
                     DocumentSnapshot document = task.getDocuments().get(0);
-                    // TODO: Remove explicit User object creation when User model is refactored
-                    User user = new User(document.getId(), (String) document.get(USERNAME_FIELD), (String) document.get(EMAIL_FIELD));
-                    onFinished.finished(true, user);
+                    onFinished.finished(true, document.toObject(User.class));
                 });
     }
 

--- a/app/src/main/java/com/example/unlibrary/profile/ProfileViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/profile/ProfileViewModel.java
@@ -101,7 +101,7 @@ public class ProfileViewModel extends ViewModel {
      * Reset text fields to previous state
      */
     public void resetUserInfo() {
-        mUser.setValue(new User(mUser.getValue().getId(), mOldUserName, mOldEmail));
+        mUser.setValue(new User(mUser.getValue().getUID(), mOldUserName, mOldEmail));
         mPassword.setValue("");
         mInvalidInputEvent.setValue(new Pair<>(AuthUtil.InputKey.PASSWORD, null));
         mInvalidInputEvent.setValue(new Pair<>(AuthUtil.InputKey.EMAIL, null));


### PR DESCRIPTION
# Summary
- Updates the `User` object to use `@DocumentID` so that Firestore can automatically set the user's ID when retrieving the document
- I added a Firestore rule as well, I'm not 100% sure about this so would appreciate feedback on that as well: 
![image](https://user-images.githubusercontent.com/32345990/97904312-8a729200-1cfd-11eb-98f2-6cc34b5efa87.png)

Closes #73
