### PR TITLE
Fix: Crash bug on fetching current user 

### DIFF
--- a/app/src/main/java/com/example/unlibrary/profile/ProfileRepository.java
+++ b/app/src/main/java/com/example/unlibrary/profile/ProfileRepository.java
@@ -49,11 +49,10 @@ public class ProfileRepository {
         mUser = FirebaseAuth.getInstance().getCurrentUser();
         mUID = mUser.getUid();
         mDB.collection(USERS_COLLECTION)
-                .whereEqualTo(UID_FIELD, mUID)
+                .document(mUID)
                 .get()
                 .addOnSuccessListener(task -> {
-                    DocumentSnapshot document = task.getDocuments().get(0);
-                    onFinished.finished(true, document.toObject(User.class));
+                    onFinished.finished(true, task.toObject(User.class));
                 });
     }
 


### PR DESCRIPTION
# Summary
- Previous PR (#73) updated the `user` model class to be compatible with Firestore (added `@DocumentID`) but did not update the query to fetch the current user 
- Note: adding the `@DocumentID` removes the id field in firestore

Closes #86 
