### PR TITLE
Add toast on successful request and refined detailed exchange book view

### DIFF
--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -49,7 +49,7 @@ public class ExchangeBookDetailsFragment extends Fragment {
 
         // Setup observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
-        mViewModel.getFailureNavMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
+        mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 
         return mBinding.getRoot();
     }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeBookDetailsFragment.java
@@ -49,7 +49,7 @@ public class ExchangeBookDetailsFragment extends Fragment {
 
         // Setup observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.addRequest).navigate(navDirections));
-        mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
+        mViewModel.getFailureNavMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
 
         return mBinding.getRoot();
     }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeFragment.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.example.unlibrary.MainActivity;
 import com.example.unlibrary.book_list.BooksFragment;
 import com.example.unlibrary.databinding.FragmentExchangeBinding;
 
@@ -63,6 +64,7 @@ public class ExchangeFragment extends Fragment {
             }
         }
 
+        mViewModel.getSuccessRequestMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
         return mBinding.getRoot();
     }
 }

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -36,7 +36,7 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     private final ExchangeRepository mExchangeRepository;
     private final MutableLiveData<Book> mCurrentBook = new MutableLiveData<>();
     private final SingleLiveEvent<NavDirections> mNavigationEvent = new SingleLiveEvent<>();
-    private final SingleLiveEvent<String> mFailureNavMsgEvent = new SingleLiveEvent<>();
+    private final SingleLiveEvent<String> mFailureMsgEvent = new SingleLiveEvent<>();
     private final SingleLiveEvent<String> mSuccessRequestMsgEvent = new SingleLiveEvent<>();
 
     /**
@@ -52,8 +52,8 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      *
      * @return Event of failure message to display
      */
-    public SingleLiveEvent<String> getFailureNavMsgEvent() {
-        return mFailureNavMsgEvent;
+    public SingleLiveEvent<String> getFailureMsgEvent() {
+        return mFailureMsgEvent;
     }
 
     /**
@@ -104,7 +104,7 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
                     mSuccessRequestMsgEvent.setValue("Request successfully sent");
                 },
                 e -> {
-                    mFailureNavMsgEvent.setValue("Failed to send request.");
+                    mFailureMsgEvent.setValue("Failed to send request.");
                     Log.e(TAG, "Failed to send request.", e);
                 });
     }
@@ -117,7 +117,7 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      */
     public void selectCurrentBook(View view, int position) {
         if (mBooks.getValue() == null) {
-            mFailureNavMsgEvent.setValue("Failed show details for book");
+            mFailureMsgEvent.setValue("Failed show details for book");
             return;
         }
 

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeViewModel.java
@@ -10,6 +10,7 @@ package com.example.unlibrary.exchange;
 
 import android.util.Log;
 import android.view.View;
+import android.widget.Toast;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
@@ -21,6 +22,7 @@ import com.example.unlibrary.book_list.BooksSource;
 import com.example.unlibrary.models.Book;
 import com.example.unlibrary.models.Request;
 import com.example.unlibrary.util.SingleLiveEvent;
+import com.google.android.material.snackbar.Snackbar;
 
 import java.util.List;
 
@@ -34,7 +36,8 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
     private final ExchangeRepository mExchangeRepository;
     private final MutableLiveData<Book> mCurrentBook = new MutableLiveData<>();
     private final SingleLiveEvent<NavDirections> mNavigationEvent = new SingleLiveEvent<>();
-    private final SingleLiveEvent<String> mFailureMsgEvent = new SingleLiveEvent<>();
+    private final SingleLiveEvent<String> mFailureNavMsgEvent = new SingleLiveEvent<>();
+    private final SingleLiveEvent<String> mSuccessRequestMsgEvent = new SingleLiveEvent<>();
 
     /**
      * Constructor for the ExchangeViewModel. Instantiates listener to Firestore.
@@ -49,8 +52,8 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      *
      * @return Event of failure message to display
      */
-    public SingleLiveEvent<String> getFailureMsgEvent() {
-        return mFailureMsgEvent;
+    public SingleLiveEvent<String> getFailureNavMsgEvent() {
+        return mFailureNavMsgEvent;
     }
 
     /**
@@ -60,6 +63,16 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      */
     public SingleLiveEvent<NavDirections> getNavigationEvent() {
         return mNavigationEvent;
+    }
+
+
+    /**
+     * SuccessMsgEvent getter for activity observers.
+     *
+     * @return Event of which fragment to navigate to
+     */
+    public SingleLiveEvent<String> getSuccessRequestMsgEvent() {
+        return mSuccessRequestMsgEvent;
     }
 
     /**
@@ -88,9 +101,10 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
         mExchangeRepository.createRequest(request,
                 o -> {
                     mNavigationEvent.setValue(ExchangeBookDetailsFragmentDirections.actionExchangeBookDetailsFragmentToExchangeFragment());
+                    mSuccessRequestMsgEvent.setValue("Request successfully sent");
                 },
                 e -> {
-                    mFailureMsgEvent.setValue("Failed to send request.");
+                    mFailureNavMsgEvent.setValue("Failed to send request.");
                     Log.e(TAG, "Failed to send request.", e);
                 });
     }
@@ -103,7 +117,7 @@ public class ExchangeViewModel extends ViewModel implements BooksSource {
      */
     public void selectCurrentBook(View view, int position) {
         if (mBooks.getValue() == null) {
-            mFailureMsgEvent.setValue("Failed show details for book");
+            mFailureNavMsgEvent.setValue("Failed show details for book");
             return;
         }
 

--- a/app/src/main/res/layout/fragment_exchange_book_details.xml
+++ b/app/src/main/res/layout/fragment_exchange_book_details.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -13,16 +14,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/profileImage"
-            layout="@layout/fragment_image_holder"
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/bookImage"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:scaleType="centerCrop"
             app:layout_constraintHeight_percent="0.4"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:subtitle="@{viewModel.currentBook.author}"
-            app:title="@{viewModel.currentBook.title}" />
+            tools:imagePath="@{viewModel.currentBook.photo}" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/add_request"
@@ -32,9 +32,53 @@
             android:layout_marginBottom="24dp"
             android:contentDescription="@string/edit_book_fab_description"
             android:onClick="@{()->viewModel.sendRequest()}"
-            app:layout_constraintBottom_toBottomOf="@+id/profileImage"
+            app:layout_constraintBottom_toBottomOf="@+id/bookImage"
             app:layout_constraintEnd_toEndOf="parent"
             app:srcCompat="@drawable/ic_add" />
+
+        <TextView
+            android:id="@+id/textView6"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="16dp"
+            android:text="@string/title"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/bookImage" />
+
+        <TextView
+            android:id="@+id/textView7"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="8dp"
+            android:text="@{viewModel.currentBook.title}"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView6" />
+
+        <TextView
+            android:id="@+id/textView8"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="16dp"
+            android:text="@string/author"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView7" />
+
+        <TextView
+            android:id="@+id/textView9"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/text_margin"
+            android:layout_marginTop="8dp"
+            android:text="@{viewModel.currentBook.author}"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView8" />
 
         <TextView
             android:id="@+id/textView"
@@ -45,7 +89,7 @@
             android:text="@string/isbn"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/profileImage" />
+            app:layout_constraintTop_toBottomOf="@+id/textView9" />
 
         <TextView
             android:id="@+id/textView5"


### PR DESCRIPTION
# Summary
- A toast is shown when a request was successfully sent
- The book image is now displayed in detail exchange book view
- Pushed information down in the detail view to read more easily

# TODO
- Update exchange book list when a request is sent

# Screenshots
![detailed exchange](https://user-images.githubusercontent.com/44874031/98180024-5c3bb080-1ebd-11eb-9386-efe65a610b6d.PNG)
![toast](https://user-images.githubusercontent.com/44874031/98180032-5f36a100-1ebd-11eb-9552-f9e6d3de4222.PNG)

Closes #79 
