### PR TITLE
Implement book handoff process (borrow and return)

### DIFF
--- a/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
@@ -87,7 +87,6 @@ public class LibraryBookDetailsFragment extends BookDetailFragment {
         });
         // Long click as backup for books where you can't scan the isbn
         mBinding.handoffBook.setOnLongClickListener(v -> {
-            // TODO implement some sort of dialog to force user to reenter isbn and verify they have the book in hand?
             mViewModel.handoff(mViewModel.getCurrentBook().getValue().getIsbn());
             return true;
         });

--- a/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
@@ -8,13 +8,14 @@
 
 package com.example.unlibrary.library;
 
-import android.app.AlertDialog;
-import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.DividerItemDecoration;
@@ -24,9 +25,12 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.unlibrary.MainActivity;
 import com.example.unlibrary.book_detail.BookDetailFragment;
 import com.example.unlibrary.databinding.FragmentLibraryBookDetailsBinding;
+import com.example.unlibrary.util.BarcodeScanner;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -36,8 +40,11 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class LibraryBookDetailsFragment extends BookDetailFragment {
 
+    public static final String SCAN_TAG = "com.example.unlibrary.library.LibraryBookDetailsFragment";
     private FragmentLibraryBookDetailsBinding mBinding;
     private LibraryViewModel mViewModel;
+    private Uri mHandoffIsbnUri;
+    private ActivityResultLauncher<Uri> mScanBarcodeContract;
 
     /**
      * Setup the fragment
@@ -59,6 +66,31 @@ public class LibraryBookDetailsFragment extends BookDetailFragment {
         // Setup observers
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.editBook).navigate(navDirections));
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
+
+        // Setup scanBarcode contract
+        mScanBarcodeContract = registerForActivityResult(new ActivityResultContracts.TakePicture(), result -> {
+            if (result) {
+                BarcodeScanner.scanBarcode(requireActivity().getApplicationContext(), mHandoffIsbnUri, SCAN_TAG, mViewModel);
+            } else {
+                showToast("Failed to get photo.");
+            }
+        });
+
+        // Setup handoff button. This is done in fragment because camera requires a lot of access to application context
+        mBinding.handoffBook.setOnClickListener(v -> {
+            try {
+                mHandoffIsbnUri = ((MainActivity) requireActivity()).buildFileUri();
+                mScanBarcodeContract.launch(mHandoffIsbnUri);
+            } catch (IOException e) {
+                showToast("Failed to build uri.");
+            }
+        });
+        // Long click as backup for books where you can't scan the isbn
+        mBinding.handoffBook.setOnLongClickListener(v -> {
+            // TODO implement some sort of dialog to force user to reenter isbn and verify they have the book in hand?
+            mViewModel.handoff(mViewModel.getCurrentBook().getValue().getIsbn());
+            return true;
+        });
 
         // Setup delete button. This is done in fragment because a confirmation dialog should be displayed first
         mBinding.deleteBook.setOnClickListener(v -> {
@@ -97,5 +129,14 @@ public class LibraryBookDetailsFragment extends BookDetailFragment {
     public void onDestroyView() {
         super.onDestroyView();
         mViewModel.detachRequestersListener();
+    }
+
+    /**
+     * Utility to show a toast via the MainActivity.
+     *
+     * @param msg Message to show
+     */
+    private void showToast(String msg) {
+        ((MainActivity) requireActivity()).showToast(msg);
     }
 }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryEditBookFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryEditBookFragment.java
@@ -36,6 +36,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class LibraryEditBookFragment extends Fragment {
 
+    public static final String SCAN_TAG = "com.example.unlibrary.library.LibraryEditBookFragment";
     private LibraryViewModel mViewModel;
     private FragmentLibraryEditBookBinding mBinding;
     private Uri mAutofillUri;
@@ -81,7 +82,7 @@ public class LibraryEditBookFragment extends Fragment {
         // Setup scanBarcode contract
         mScanBarcodeContract = registerForActivityResult(new ActivityResultContracts.TakePicture(), result -> {
             if (result) {
-                BarcodeScanner.scanBarcode(requireActivity().getApplicationContext(), mAutofillUri, mViewModel);
+                BarcodeScanner.scanBarcode(requireActivity().getApplicationContext(), mAutofillUri, SCAN_TAG, mViewModel);
             } else {
                 showToast("Failed to get photo.");
             }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -223,7 +223,7 @@ public class LibraryRepository {
      * @param bookID requests on this book will be listened to
      */
     public void attachRequestsListener(String bookID) {
-        Query query = mDb.collection(REQUESTS_COLLECTION).whereEqualTo("book", bookID);
+        Query query = mDb.collection(REQUESTS_COLLECTION).whereEqualTo(BOOK, bookID).whereNotEqualTo(STATE, Request.State.ARCHIVED);
 
         // TODO only use getDocumentChanges instead of rebuilding the entire list
         mRequestsListenerRegistration = query.addSnapshotListener((snapshot, error) -> {

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -265,7 +265,13 @@ public class LibraryRepository {
         mRequestsListenerRegistration.remove();
     }
 
-    // TODO use existing code
+    /**
+     * Get the borrowed request associated with the current book.
+     *
+     * @param book              book request is associated with
+     * @param onSuccessListener code to call on success
+     * @param onFailureListener code to call on failure
+     */
     public void getBorrowedRequest(Book book, OnSuccessListener<? super QuerySnapshot> onSuccessListener, OnFailureListener onFailureListener) {
         Query query = mDb.collection(REQUESTS_COLLECTION).whereEqualTo(BOOK, book.getId()).whereEqualTo(STATE, Request.State.BORROWED.toString());
         query.get().addOnSuccessListener(onSuccessListener).addOnFailureListener(onFailureListener);

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -29,6 +29,8 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.WriteBatch;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +47,10 @@ public class LibraryRepository {
     private static final String BOOKS_COLLECTION = "books";
     private static final String REQUESTS_COLLECTION = "requests";
     private static final String USERS_COLLECTION = "users";
+    private static final String BOOK = "book";
+    private static final String STATE = "state";
+    private static final String STATUS = "status";
+    private static final String IS_READY_FOR_HANDOFF = "isReadyForHandoff";
     private static final String TAG = LibraryRepository.class.getSimpleName();
 
     private FirebaseFirestore mDb;
@@ -257,5 +263,33 @@ public class LibraryRepository {
      */
     public void detachRequestersListener() {
         mRequestsListenerRegistration.remove();
+    }
+
+    // TODO use existing code
+    public void getBorrowedRequest(Book book, OnSuccessListener<? super QuerySnapshot> onSuccessListener, OnFailureListener onFailureListener) {
+        Query query = mDb.collection(REQUESTS_COLLECTION).whereEqualTo(BOOK, book.getId()).whereEqualTo(STATE, Request.State.BORROWED.toString());
+        query.get().addOnSuccessListener(onSuccessListener).addOnFailureListener(onFailureListener);
+    }
+
+    /**
+     * Update state and status of request and book
+     *
+     * @param request           request object to be updated in the database
+     * @param book              book object to update
+     * @param onSuccessListener code to call on success
+     * @param onFailureListener code to call on failure
+     */
+    public void completeExchange(Request request, Book book, OnSuccessListener<Void> onSuccessListener, OnFailureListener onFailureListener) {
+        WriteBatch batch = mDb.batch();
+        DocumentReference requestCol = mDb.collection(REQUESTS_COLLECTION).document(request.getId());
+        DocumentReference bookCol = mDb.collection(BOOKS_COLLECTION).document(book.getId());
+
+        requestCol.update(STATE, request.getState());
+        bookCol.update(STATUS, book.getStatus());
+        bookCol.update(IS_READY_FOR_HANDOFF, book.getIsReadyForHandoff());
+
+        batch.commit()
+                .addOnSuccessListener(onSuccessListener)
+                .addOnFailureListener(onFailureListener);
     }
 }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -418,7 +418,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     /**
      * Autofill the current book from scan data
      *
-     * @param isbn isbn that was scanned
+     * @param isbn scanned isbn
      */
     private void scanAutoFill(String isbn) {
         if (isbn == null || isbn.isEmpty()) {

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -26,7 +26,6 @@ import com.example.unlibrary.book_list.BooksSource;
 import com.example.unlibrary.models.Book;
 import com.example.unlibrary.models.Request;
 import com.example.unlibrary.models.User;
-import com.example.unlibrary.unlibrary.UnlibraryBookDetailsFragmentDirections;
 import com.example.unlibrary.util.BarcodeScanner;
 import com.example.unlibrary.util.SingleLiveEvent;
 import com.google.firebase.storage.FirebaseStorage;
@@ -37,7 +36,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -353,15 +353,24 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     }
 
     /**
-     * Handoff a book to a chose requester.
+     * Handoff a book to a chosen requester.
      *
      * @param isbn isbn of book to handoff
      */
     public void handoff(String isbn) {
         if (mCurrentBook.getValue().getStatus() == Book.Status.ACCEPTED) {
-            // TODO
+            // Giving book away
+            if (!mCurrentBook.getValue().getIsbn().equals(isbn)) {
+                mFailureMsgEvent.setValue("Isbn does not match current book.");
+                return;
+            }
+            Book b = mCurrentBook.getValue();
+            b.setStatus(Book.Status.BORROWED);
+            mLibraryRepository.updateBook(b, aVoid -> mFailureMsgEvent.setValue("Book has been handed off."), e -> mFailureMsgEvent.setValue("Failed to handover book."));
+
         } else if (mCurrentBook.getValue().getStatus() == Book.Status.BORROWED) {
             // TODO
+            // Returning book
         } else {
             Log.w(TAG, "Handoff called for an invalid book status.");
         }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -348,7 +348,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         } else if (tag.equals(LibraryBookDetailsFragment.SCAN_TAG)) {
             handoff(isbn);
         } else {
-            Log.i(TAG, "Invalid scan_tag encountered.");
+            Log.w(TAG, "Invalid scan_tag encountered.");
         }
     }
 
@@ -358,11 +358,17 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
      * @param isbn isbn of book to handoff
      */
     public void handoff(String isbn) {
-        return; // TODO
+        if (mCurrentBook.getValue().getStatus() == Book.Status.ACCEPTED) {
+            // TODO
+        } else if (mCurrentBook.getValue().getStatus() == Book.Status.BORROWED) {
+            // TODO
+        } else {
+            Log.w(TAG, "Handoff called for an invalid book status.");
+        }
     }
 
     /**
-     * Autofill the current book from scan data
+     * Autofill the current book from scan datag
      *
      * @param isbn isbn that was scanned
      */

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -197,7 +197,6 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         mLibraryRepository.setFilter(mFilter);
     }
 
-
     /**
      * Save the book that is currently being created or edited
      */
@@ -339,10 +338,35 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     /**
      * Code to be called when a barcode scan is finished successfully.
      *
+     * @param tag  Identifier for what is using scan barcode.
      * @param isbn isbn from successful scan
      */
     @Override
-    public void onFinishedScanSuccess(String isbn) {
+    public void onFinishedScanSuccess(String tag, String isbn) {
+        if (tag.equals(LibraryEditBookFragment.SCAN_TAG)) {
+            scanAutoFill(isbn);
+        } else if (tag.equals(LibraryBookDetailsFragment.SCAN_TAG)) {
+            handoff(isbn);
+        } else {
+            Log.i(TAG, "Invalid scan_tag encountered.");
+        }
+    }
+
+    /**
+     * Handoff a book to a chose requester.
+     *
+     * @param isbn isbn of book to handoff
+     */
+    public void handoff(String isbn) {
+        return; // TODO
+    }
+
+    /**
+     * Autofill the current book from scan data
+     *
+     * @param isbn isbn that was scanned
+     */
+    private void scanAutoFill(String isbn) {
         if (isbn == null || isbn.isEmpty()) {
             mFailureMsgEvent.setValue("Invalid ISBN found");
             return;
@@ -400,10 +424,11 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     /**
      * Code to be called when a barcode scan fails.
      *
-     * @param e Throwable
+     * @param tag Identifier for what is using barcode scan.
+     * @param e   Throwable
      */
     @Override
-    public void onFinishedScanFailure(Throwable e) {
+    public void onFinishedScanFailure(String tag, Throwable e) {
         mFailureMsgEvent.setValue("Failed to scan barcode.");
         Log.e(TAG, "Failed to scan barcode.", e);
     }

--- a/app/src/main/java/com/example/unlibrary/models/Book.java
+++ b/app/src/main/java/com/example/unlibrary/models/Book.java
@@ -26,6 +26,7 @@ public class Book {
     private String mOwner;
     private String mPhoto;
     private Status mStatus;
+    private Boolean mIsReadyForHandoff;
 
     /**
      * Empty constructor. Needed for Firestore.
@@ -49,6 +50,7 @@ public class Book {
         mAuthor = author;
         mOwner = owner;
         mStatus = Status.AVAILABLE;
+        mIsReadyForHandoff = false;
         mPhoto = photo;
     }
 
@@ -193,6 +195,24 @@ public class Book {
      */
     public void setTitle(String title) {
         mTitle = title;
+    }
+
+    /**
+     * Gets the isReadyForHandoff status of a book.
+     *
+     * @return isReadyForHandoff status of current book
+     */
+    public Boolean getIsReadyForHandoff() {
+        return mIsReadyForHandoff;
+    }
+
+    /**
+     * Updates the isReadyForHandoff status of the book.
+     *
+     * @param isReadyForHandoff updated isReadyForHandoff status
+     */
+    public void setIsReadyForHandoff(Boolean isReadyForHandoff) {
+        mIsReadyForHandoff = isReadyForHandoff;
     }
 
     // TODO: Check if there's a better way of holding this information without making another fetch request to the database to retrieve Requests

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryBookDetailsFragment.java
@@ -81,7 +81,6 @@ public class UnlibraryBookDetailsFragment extends BookDetailFragment {
         });
         // Long click as backup for books where you can't scan the isbn
         mBinding.handBook.setOnLongClickListener(v -> {
-            // TODO implement some sort of dialog to force user to reenter isbn and verify they have the book in hand?
             mViewModel.handoff(mViewModel.getCurrentBook().getValue().getIsbn());
             return true;
         });

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryBookDetailsFragment.java
@@ -7,19 +7,25 @@
  */
 package com.example.unlibrary.unlibrary;
 
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 
 import com.example.unlibrary.MainActivity;
 import com.example.unlibrary.book_detail.BookDetailFragment;
 import com.example.unlibrary.databinding.FragmentUnlibraryBookDetailsBinding;
+import com.example.unlibrary.util.BarcodeScanner;
 
 import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
 
 import dagger.hilt.android.AndroidEntryPoint;
 
@@ -29,7 +35,10 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class UnlibraryBookDetailsFragment extends BookDetailFragment {
 
+    public static final String SCAN_TAG = "com.example.unlibrary.unlibrary.UnlibraryBookDetailsFragment";
     private FragmentUnlibraryBookDetailsBinding mBinding;
+    private Uri mHandoffIsbnUri;
+    private ActivityResultLauncher<Uri> mScanBarcodeContract;
 
     /**
      * Setup the fragment
@@ -51,6 +60,31 @@ public class UnlibraryBookDetailsFragment extends BookDetailFragment {
         // Setup observer
         mViewModel.getNavigationEvent().observe(this, navDirections -> Navigation.findNavController(mBinding.handBook).navigate(navDirections));
         mViewModel.getFailureMsgEvent().observe(this, s -> ((MainActivity) requireActivity()).showToast(s));
+
+        // Setup scanBarcode contract
+        mScanBarcodeContract = registerForActivityResult(new ActivityResultContracts.TakePicture(), result -> {
+            if (result) {
+                BarcodeScanner.scanBarcode(requireActivity().getApplicationContext(), mHandoffIsbnUri, SCAN_TAG, mViewModel);
+            } else {
+                ((MainActivity) requireActivity()).showToast("Failed to get photo");
+            }
+        });
+
+        // Setup handoff button. This is done in fragment because camera requires a lot of access to application context
+        mBinding.handBook.setOnClickListener(v -> {
+            try {
+                mHandoffIsbnUri = ((MainActivity) requireActivity()).buildFileUri();
+                mScanBarcodeContract.launch(mHandoffIsbnUri);
+            } catch (IOException e) {
+                ((MainActivity) requireActivity()).showToast("Failed to build uri.");
+            }
+        });
+        // Long click as backup for books where you can't scan the isbn
+        mBinding.handBook.setOnLongClickListener(v -> {
+            // TODO implement some sort of dialog to force user to reenter isbn and verify they have the book in hand?
+            mViewModel.handoff(mViewModel.getCurrentBook().getValue().getIsbn());
+            return true;
+        });
 
         mBinding.bookImageButton.setOnClickListener(v -> zoomImageFromThumb(mBinding.unlibraryBookFrame, mBinding.bookImageButton, mBinding.bookImage));
         return mBinding.getRoot();

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
@@ -8,30 +8,24 @@
 package com.example.unlibrary.unlibrary;
 
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.lifecycle.MutableLiveData;
 
 import com.example.unlibrary.models.Book;
 import com.example.unlibrary.models.Request;
-import com.example.unlibrary.models.User;
-
-import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.ListenerRegistration;
-import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.WriteBatch;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -47,7 +41,7 @@ public class UnlibraryRepository {
     private static final String BOOK = "book";
     private static final String STATE = "state";
     private static final String STATUS = "status";
-
+    private static final String IS_READY_FOR_HANDOFF = "isReadyForHandoff";
 
     private final FirebaseFirestore mDb;
     private final MutableLiveData<List<Book>> mBooks = new MutableLiveData<>(new ArrayList<>());
@@ -147,11 +141,26 @@ public class UnlibraryRepository {
 
         requestCol.update(STATE, request.getState());
         bookCol.update(STATUS, book.getStatus());
+        bookCol.update(IS_READY_FOR_HANDOFF, book.getIsReadyForHandoff());
 
         batch.commit()
                 .addOnSuccessListener(onSuccessListener)
                 .addOnFailureListener(onFailureListener);
 
+    }
+
+    /**
+     * Update a book document.
+     *
+     * @param book              book object to be updated in the database.
+     * @param onSuccessListener code to call on success
+     * @param onFailureListener code to call on failure
+     */
+    public void updateBook(Book book, OnSuccessListener<? super Void> onSuccessListener, OnFailureListener onFailureListener) {
+        mDb.collection(BOOK_COLLECTION).document(book.getId())
+                .set(book)
+                .addOnSuccessListener(onSuccessListener)
+                .addOnFailureListener(onFailureListener);
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
@@ -85,7 +85,6 @@ public class UnlibraryViewModel extends ViewModel implements BooksSource, Barcod
      * @return ShowHandoffButton LiveData
      */
     public LiveData<Boolean> showHandoffButton() {
-        // TODO do I need to worry about state of request at all?
         return Transformations.map(mCurrentBook, input -> {
             if (input.getStatus() == Book.Status.ACCEPTED && input.getIsReadyForHandoff()) {
                 return true;

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
@@ -137,6 +137,8 @@ public class UnlibraryViewModel extends ViewModel implements BooksSource {
         Request request = mCurrentRequest.getValue();
         Book book = mCurrentBook.getValue();
 
+
+
         request.setState(Request.State.ACCEPTED);
         book.setStatus(Book.Status.BORROWED);
 

--- a/app/src/main/java/com/example/unlibrary/util/BarcodeScanner.java
+++ b/app/src/main/java/com/example/unlibrary/util/BarcodeScanner.java
@@ -11,6 +11,9 @@ package com.example.unlibrary.util;
 import android.content.Context;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.mlkit.vision.barcode.Barcode;
 import com.google.mlkit.vision.barcode.BarcodeScannerOptions;
 import com.google.mlkit.vision.barcode.BarcodeScanning;
@@ -28,9 +31,10 @@ public class BarcodeScanner {
      *
      * @param context    Application context needed to access image
      * @param uri        Uri of the image that should be scanned.
+     * @param tag        Allows a single implementation of OnFinishedScanListener to handle multiple types of scans.
      * @param onFinished Callbacks to invoke when scan succeeds or fails.
      */
-    public static void scanBarcode(Context context, Uri uri, OnFinishedScanListener onFinished) {
+    public static void scanBarcode(Context context, Uri uri, String tag, OnFinishedScanListener onFinished) {
         InputImage image = null;
         try {
             image = InputImage.fromFilePath(context, uri);
@@ -59,12 +63,12 @@ public class BarcodeScanner {
                         }
                     }
                     if (isbn == null || isbn.isEmpty()) {
-                        onFinished.onFinishedScanFailure(new FailedToScan("No ISBN barcode found."));
+                        onFinished.onFinishedScanFailure(tag, new FailedToScan("No ISBN barcode found."));
                     } else {
-                        onFinished.onFinishedScanSuccess(isbn);
+                        onFinished.onFinishedScanSuccess(tag, isbn);
                     }
                 })
-                .addOnFailureListener(onFinished::onFinishedScanFailure);
+                .addOnFailureListener(e -> onFinished.onFinishedScanFailure(tag, e));
     }
 
     /**
@@ -86,8 +90,8 @@ public class BarcodeScanner {
      * Callbacks to be invoked when scan finishes.
      */
     public interface OnFinishedScanListener {
-        void onFinishedScanSuccess(String isbn);
+        void onFinishedScanSuccess(String tag, String isbn);
 
-        void onFinishedScanFailure(Throwable e);
+        void onFinishedScanFailure(String tag, Throwable e);
     }
 }

--- a/app/src/main/res/drawable/ic_baseline_swap_vert_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_swap_vert_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16,17.01V10h-2v7.01h-3L15,21l4,-3.99h-3zM9,3L5,6.99h3V14h2V6.99h3L9,3z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_library_book_details.xml
+++ b/app/src/main/res/layout/fragment_library_book_details.xml
@@ -43,7 +43,7 @@
                     android:layout_height="wrap_content"
                     android:layout_margin="16dp"
                     android:layout_marginBottom="4dp"
-                    android:contentDescription="Handoff Book"
+                    android:contentDescription="@string/handoff_book"
                     app:backgroundTint="@color/colorAccent"
                     app:layout_constraintBottom_toBottomOf="@+id/bookImageButton"
                     app:layout_constraintEnd_toStartOf="@+id/edit_book"

--- a/app/src/main/res/layout/fragment_library_book_details.xml
+++ b/app/src/main/res/layout/fragment_library_book_details.xml
@@ -36,6 +36,19 @@
                     tools:imagePath="@{viewModel.currentBook.photo}" />
 
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/handoff_book"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="Handoff Book"
+                    app:backgroundTint="@color/colorAccent"
+                    app:layout_constraintBottom_toBottomOf="@+id/bookImageButton"
+                    app:layout_constraintEnd_toStartOf="@+id/edit_book"
+                    app:layout_constraintTop_toBottomOf="@+id/bookImageButton"
+                    app:srcCompat="@drawable/ic_baseline_swap_vert_24" />
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/edit_book"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -186,6 +199,7 @@
                 android:layout_height="match_parent"
                 android:visibility="invisible"
                 tools:imagePath="@{viewModel.currentBook.photo}" />
+
         </FrameLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/fragment_library_book_details.xml
+++ b/app/src/main/res/layout/fragment_library_book_details.xml
@@ -10,6 +10,8 @@
             type="com.example.unlibrary.library.LibraryViewModel" />
 
         <import type="android.view.View" />
+
+        <import type="com.example.unlibrary.models.Book" />
     </data>
 
     <ScrollView

--- a/app/src/main/res/layout/fragment_unlibrary_book_details.xml
+++ b/app/src/main/res/layout/fragment_unlibrary_book_details.xml
@@ -41,7 +41,7 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="4dp"
                 android:contentDescription="@string/handoff_book_description"
-                android:onClick="@{()->viewModel.confirmHandoff()}"
+                android:visibility="@{viewModel.showHandoffButton ? View.VISIBLE : View.GONE}"
                 app:layout_constraintBottom_toBottomOf="@+id/bookImageButton"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/bookImageButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
     <string name="borrowed">Borrowed</string>
     <string name="requesters">Requesters</string>
     <string name="handoff_book_fab_description">Handoff book</string>
+    <string name="handoff_book">Handoff Book</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
     <string name="accepted">Accepted</string>
     <string name="borrowed">Borrowed</string>
     <string name="requesters">Requesters</string>
+    <string name="handoff_book_fab_description">Handoff book</string>
 </resources>


### PR DESCRIPTION
# Summary
- Implement handoff flow (More details on this later)
- Add `isReadyForHandoff: boolean` field to `book` document. Required for handoff flow
- Filter out archived requests when querying for a books requesters

# Handoff flow
1. Owner accepts a single request on a book, all others are declined/archived.
2. When ready, owner scans book and it is marked as ready to handoff.
3. Borrower scans book. Book is marked as borrowed and not ready to handoff, request is marked as borrowed.
4. When ready, borrower scans book and it is marked as ready to handoff.
5. Owner scans book. Book is marked as available and not ready to handoff, request is marked as archived.

# Implementation Details
I added the `isReadyForHandoff` so that the handoff process would be atomic. Without this intermediary step, it is imaginable that an owner would scan and update the status of a book, and the borrower would not scan. This would leave the book in a state that we wouldn't know how to recover from. Rather all things should be updated at once when both parties have scanned.

# TODO
- Possibly add functionality to reverse the marking of a book as ready for handoff i.e. Fixing scenario where an owner scans a book but the borrower never scans it

closes #101 
