### PR TITLE
Fix search and status in Exchange

### DIFF
--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -49,7 +49,7 @@ public class ExchangeRepository {
 
     // Algolia fields
     private static final String ALGOLIA_INDEX_NAME = "books";
-    private static final String ALGOLIA_ID_FIELD = "id";
+    private static final String ALGOLIA_ID_FIELD = "objectID";
     private String previousSearch;
 
     private static final String TAG = ExchangeRepository.class.getSimpleName();

--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -127,19 +127,6 @@ public class ExchangeRepository {
     }
 
     /**
-     * Save new Request into the database. Assumes Request is valid.
-     *
-     * @param request           request object to be saved in the database
-     * @param onSuccessListener code to call on success
-     * @param onFailureListener code to call on failure
-     */
-    public void createRequest(Request request, OnSuccessListener<DocumentReference> onSuccessListener, OnFailureListener onFailureListener) {
-        mDb.collection(REQUEST_COLLECTION).add(request)
-                .addOnSuccessListener(onSuccessListener)
-                .addOnFailureListener(onFailureListener);
-    }
-
-    /**
      * Gets the observable list of books that are available to be requested for. This includes all
      * books that are not currently being borrowed or has been accepted. Status is always set to
      * AVAILABLE.

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -64,7 +64,7 @@ public class LibraryRepository {
     // TODO: Consider using POJOs for algolia
     private static final String ALGOLIA_TITLE_FIELD = "title";
     private static final String ALGOLIA_AUTHOR_FIELD = "author";
-    private static final String ALGOLIA_ID_FIELD = "id";
+    private static final String ALGOLIA_ID_FIELD = "objectID";
     private final Client mAlgoliaClient;
     private FirebaseFirestore mDb;
     private FirebaseAuth mAuth;
@@ -170,6 +170,13 @@ public class LibraryRepository {
                 .delete()
                 .addOnSuccessListener(onSuccessListener)
                 .addOnFailureListener(onFailureListener);
+
+        mAlgoliaClient.getIndex(ALGOLIA_INDEX_NAME)
+                .deleteObjectAsync(book.getId(), (jsonObject, e) -> {
+                    if (e != null) {
+                        Log.e(TAG, "Unable to delete book " + book.getId(), e);
+                    }
+                });
     }
 
     /**


### PR DESCRIPTION
# Summary
- Search previously includes all books that have that title, now client filters it to only include books that are requestable (not borrowed or accepted, and not yours)
  - Trade off of not storing status and owner in algolia while minimizing search requests in server
  - Assumes not many of the book requests will be discarded
- ObjectID in Algolia now matches book ID in Firestore to eliminate redundancy

Solves half of #122 