### PR TITLE
Remove books associated with archived requests from unlibrary

### DIFF
--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
@@ -80,6 +80,7 @@ public class UnlibraryRepository {
     public void attachListeners() {
         mListenerRegistration = mDb.collection(REQUEST_COLLECTION)
                 .whereEqualTo(REQUESTER, FirebaseAuth.getInstance().getUid())
+                .whereNotEqualTo(STATE, Request.State.ARCHIVED.toString())
                 .addSnapshotListener((snapshot, error) -> {
                     if (error != null) {
                         Log.e(TAG, "Unable to get requests from database", error);


### PR DESCRIPTION
# Summary
One line fix to ensure we don't show books associated with archived requests in unlibrary (hence removing duplicates that currently show up)