### PR TITLE
Fix bug where Unlibrary showed duplicate books

### DIFF
--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
@@ -103,7 +103,7 @@ public class UnlibraryRepository {
                         );
                     }
 
-
+                    mAllBooks.clear();
                     Tasks.whenAllComplete(addBookTasks)
                             .addOnSuccessListener(aVoid -> {
                                 filter();

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryRepository.java
@@ -89,6 +89,7 @@ public class UnlibraryRepository {
                     List<Request> requests = snapshot.toObjects(Request.class);
 
                     ArrayList<Task<DocumentSnapshot>> addBookTasks = new ArrayList<>();
+                    mAllBooks.clear();
 
                     for (Request r : requests) {
                         addBookTasks.add(
@@ -103,7 +104,6 @@ public class UnlibraryRepository {
                         );
                     }
 
-                    mAllBooks.clear();
                     Tasks.whenAllComplete(addBookTasks)
                             .addOnSuccessListener(aVoid -> {
                                 filter();

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
@@ -124,7 +124,7 @@ public class UnlibraryViewModel extends ViewModel implements BooksSource, Barcod
     /**
      * Getter for mCurrentBook live data object
      *
-     * @return LiveData<Book> This returns the mBooks object
+     * @return LiveData<Book> This returns the mCurrentBook object
      */
     public LiveData<Book> getCurrentBook() {
         return mCurrentBook;


### PR DESCRIPTION
Encountered bug where every time I requested a book in exchange duplicates of all the books in Unlibrary would be shown. This is because we were not clearing the book list, we were only appending to it.