### PR TITLE
Add currentBook listener for Library

### DIFF
--- a/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryBookDetailsFragment.java
@@ -110,7 +110,6 @@ public class LibraryBookDetailsFragment extends BookDetailFragment implements On
         RecyclerView recyclerView = mBinding.requestersList;
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
         recyclerView.setLayoutManager(layoutManager);
-        mViewModel.fetchRequestersForCurrentBook();
         RequestersRecyclerViewAdapter adapter = new RequestersRecyclerViewAdapter(mViewModel.getRequesters().getValue(), mViewModel::selectRequester);
 
         // Bind ViewModel books to RecyclerViewAdapter

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -81,6 +81,7 @@ public class LibraryRepository {
     private final Client mAlgoliaClient;
     private FirebaseFirestore mDb;
     private FirebaseAuth mAuth;
+    private ListenerRegistration mBookListenerRegistration;
     private ListenerRegistration mBooksListenerRegistration;
     private ListenerRegistration mRequestsListenerRegistration;
     private MutableLiveData<List<Book>> mBooks;
@@ -281,6 +282,27 @@ public class LibraryRepository {
         mCurrentBookRequesters.setValue(new ArrayList<>());
         // Attach snapshot listener for requesters on current book
         attachRequestsListener(currentBookID);
+    }
+
+    /**
+     * Sets up a listener to callback to for whenever book details are updated (e.g. status)
+     *
+     * @param bookId Firestore assigned bookId to listen to
+     */
+    public void attachListenerToBook(String bookId, OnSuccessListener<Book> listener) {
+        if (mBookListenerRegistration != null) {
+            mBookListenerRegistration.remove();
+        }
+
+         mBookListenerRegistration = mDb.collection(BOOKS_COLLECTION).document(bookId)
+                .addSnapshotListener((value, error) -> {
+                    if (error != null) {
+                        Log.e(TAG, "Error updating book details", error);
+                        return;
+                    }
+
+                    listener.onSuccess(value.toObject(Book.class));
+                });
     }
 
     /**

--- a/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryRepository.java
@@ -287,9 +287,9 @@ public class LibraryRepository {
     /**
      * Sets up a listener to callback to for whenever book details are updated (e.g. status)
      *
-     * @param bookId Firestore assigned bookId to listen to
+     * @param bookId Firestore assigned bookId (use Book::getId())
      */
-    public void attachListenerToBook(String bookId, OnSuccessListener<Book> listener) {
+    public void addBookListener(String bookId, OnSuccessListener<Book> listener) {
         if (mBookListenerRegistration != null) {
             mBookListenerRegistration.remove();
         }

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -354,7 +354,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         }
         Book book = mBooks.getValue().get(position);
         mCurrentBook.setValue(book);
-        mLibraryRepository.attachListenerToBook(book.getId(), mCurrentBook::setValue);
+        mLibraryRepository.addBookListener(book.getId(), mCurrentBook::setValue);
         mNavigationEvent.setValue(LibraryFragmentDirections.actionLibraryFragmentToLibraryBookDetailsFragment());
     }
 

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -666,6 +666,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
                 o -> {
                     // If request is successfully declined, navigate back to detailed book fragment
                     mNavigationEvent.setValue(LibraryRequesterProfileFragmentDirections.actionLibraryRequesterProfileFragmentToLibraryBookDetailsFragment());
+                    mLibraryRepository.forceUpdateRequesters(mCurrentBook.getValue().getId(), mCurrentBookRequesters::setValue);
                 },
                 e -> {
                     // If request was not successfully declined, show error message toast and log error

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -666,7 +666,6 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
                 o -> {
                     // If request is successfully declined, navigate back to detailed book fragment
                     mNavigationEvent.setValue(LibraryRequesterProfileFragmentDirections.actionLibraryRequesterProfileFragmentToLibraryBookDetailsFragment());
-                    mLibraryRepository.forceUpdateRequesters(mCurrentBook.getValue().getId(), mCurrentBookRequesters::setValue);
                 },
                 e -> {
                     // If request was not successfully declined, show error message toast and log error

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -354,6 +354,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         }
         Book book = mBooks.getValue().get(position);
         mCurrentBook.setValue(book);
+        mLibraryRepository.attachListenerToBook(book.getId(), mCurrentBook::setValue);
         mNavigationEvent.setValue(LibraryFragmentDirections.actionLibraryFragmentToLibraryBookDetailsFragment());
     }
 
@@ -694,14 +695,11 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     public void acceptSelectedRequester(LatLng latLng, SendNotificationInterface notification) {
         mLibraryRepository.acceptRequester(mSelectedRequester.getUID(), mCurrentBook.getValue().getId(), latLng,
                 o -> {
-                    Book book = mCurrentBook.getValue();
-                    book.setStatus(Book.Status.ACCEPTED);
-                    mCurrentBook.setValue(book);
                     mHandoffLocation.setValue(latLng);
                     mNavigationEvent.setValue(LibraryMapsFragmentDirections.actionMapsFragmentToLibraryBookDetailsFragment());
 
                     String target = mSelectedRequester.getUID();
-                    String body = ACCEPT_REQUEST_TEMPLATE + book.getTitle();
+                    String body = ACCEPT_REQUEST_TEMPLATE + mCurrentBook.getValue().getTitle();
                     notification.send(target, TITLE, body);
                 },
                 e -> {

--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -39,6 +39,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,7 +62,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     private FilterMap mFilter;
     private LiveData<List<Book>> mBooks;
     private final LibraryRepository mLibraryRepository;
-    private final LiveData<List<User>> mCurrentBookRequesters;
+    private final MutableLiveData<List<User>> mCurrentBookRequesters = new MutableLiveData<>(new ArrayList<>());
     private User mSelectedRequester;
     private MutableLiveData<LatLng> mHandoffLocation = new MutableLiveData<>(new LatLng(53.5461, -113.4938)); // default is Edmonton
     static final String TITLE = "REQUEST ACCEPTED";
@@ -82,7 +83,6 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         this.mFilter = new FilterMap(true);
         this.mLibraryRepository = libraryRepository;
         this.mBooks = this.mLibraryRepository.getBooks();
-        this.mCurrentBookRequesters = this.mLibraryRepository.getRequesters();
     }
 
     /**
@@ -355,6 +355,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         Book book = mBooks.getValue().get(position);
         mCurrentBook.setValue(book);
         mLibraryRepository.addBookListener(book.getId(), mCurrentBook::setValue);
+        mLibraryRepository.addBookRequestersListener(book.getId(), mCurrentBookRequesters::setValue);
         mNavigationEvent.setValue(LibraryFragmentDirections.actionLibraryFragmentToLibraryBookDetailsFragment());
     }
 
@@ -627,13 +628,6 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
         public InvalidInputException(String errorMessage) {
             super(errorMessage);
         }
-    }
-
-    /**
-     * Fetches requesters for current book
-     */
-    public void fetchRequestersForCurrentBook() {
-        mLibraryRepository.fetchRequestersForCurrentBook(mCurrentBook.getValue().getId());
     }
 
     /**


### PR DESCRIPTION
# Summary
- Declining the last requester on book will directly update the book's status to AVAILABLE
- Refactor LibraryRepository to remove state
- Remove redundant fields in LibraryRepository

# Screenshots
[Link to google photos](https://photos.app.goo.gl/f2VsYFqoE3T9oUZe7)

# Known issue
- Declining last requester doesn't trigger the snapshot listener for requesters

# TODO
- Add tests

Closes #128 
