### PR TITLE
Restrict when handoff button is shown

### DIFF
--- a/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/library/LibraryViewModel.java
@@ -120,7 +120,7 @@ public class LibraryViewModel extends ViewModel implements BarcodeScanner.OnFini
     public LiveData<Boolean> showHandoffButton() {
         return Transformations.map(mCurrentBook, input -> {
             try {
-                if (input.getStatus() == Book.Status.ACCEPTED) {
+                if (input.getStatus() == Book.Status.ACCEPTED && !input.getIsReadyForHandoff()) {
                     return true;
                 } else if (input.getStatus() == Book.Status.BORROWED && input.getIsReadyForHandoff()) {
                     return true;

--- a/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
+++ b/app/src/main/java/com/example/unlibrary/unlibrary/UnlibraryViewModel.java
@@ -115,7 +115,7 @@ public class UnlibraryViewModel extends ViewModel implements BooksSource, Barcod
         return Transformations.map(mCurrentBook, input -> {
             if (input.getStatus() == Book.Status.ACCEPTED && input.getIsReadyForHandoff()) {
                 return true;
-            } else if (input.getStatus() == Book.Status.BORROWED) {
+            } else if (input.getStatus() == Book.Status.BORROWED && !input.getIsReadyForHandoff()) {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Handoff button was still being shown after an owner/borrower had used it. I added more logic to the check so that the button is hidden after it is used.