### PR TITLE
Check if book can't be found in Firestore

### DIFF
--- a/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
+++ b/app/src/main/java/com/example/unlibrary/exchange/ExchangeRepository.java
@@ -180,6 +180,11 @@ public class ExchangeRepository {
                         .get()
                         .addOnSuccessListener(documentSnapshot -> {
                             Book book = documentSnapshot.toObject(Book.class);
+                            if (book == null) {
+                                Log.e(TAG, "Book " + bookId + " cannot be found in Firestore", null);
+                                return;
+                            }
+
                             if (!book.getOwner().equals(FirebaseAuth.getInstance().getUid()) &&
                                     mAllowedStatus.contains(book.getStatus())) {
                                 book.setStatus(Book.Status.AVAILABLE);


### PR DESCRIPTION
# Summary
- UI tests created entries in Algolia where the Firestore counterpart has been deleted
- Add a simple check for this to ignore the book

Closes #162 